### PR TITLE
Fix for #16

### DIFF
--- a/app/src/main/java/com/github/federvieh/selma/assimillib/AssimilDatabase.java
+++ b/app/src/main/java/com/github/federvieh/selma/assimillib/AssimilDatabase.java
@@ -146,7 +146,7 @@ public class AssimilDatabase {
         		Log.i("LT", "lang =   '"+language+"'");
         		Log.i("LT", "album  = '"+fullAlbum+"'");
         		Log.i("LT", "==============================================");
-        		Pattern patternAssimilPcMp3 = Pattern.compile("l([0-9][0-9][0-9])_0a");
+        		Pattern patternAssimilPcMp3 = Pattern.compile("[Ll]([0-9][0-9][0-9])(_0a)?");
         		Matcher matcherAssimilPcMp3 = patternAssimilPcMp3.matcher(fullTitle);
         		if(matcherAssimilPcMp3.find()){
         			String number = null;

--- a/app/src/main/java/com/github/federvieh/selma/assimillib/LessonPlayer.java
+++ b/app/src/main/java/com/github/federvieh/selma/assimillib/LessonPlayer.java
@@ -189,15 +189,15 @@ public class LessonPlayer extends Service implements MediaPlayer.OnErrorListener
                         //TODO: Move to extra function, add error listener
                     }
                 }
-            } else {
-                mediaPlayer.reset();
             }
-            try {
-                mediaPlayer.setDataSource(this, contentUri);
-                mediaPlayer.prepareAsync();
-            } catch (Exception e) {
-                Log.w("LT", "Could not set data source or prepare media player " + contentUri, e);
-                return;
+            if(!doCont) {
+                try {
+                    mediaPlayer.setDataSource(this, contentUri);
+                    mediaPlayer.prepareAsync();
+                } catch (Exception e) {
+                    Log.w("LT", "Could not set data source or prepare media player " + contentUri, e);
+                    return;
+                }
             }
         }
     }
@@ -313,6 +313,11 @@ public class LessonPlayer extends Service implements MediaPlayer.OnErrorListener
             delayService.cancel(true);
             delayService = null;
         }
+        // reset
+        if (mediaPlayer != null) {
+            mediaPlayer.reset();
+        }
+
         switch (pm) {
 /*		case SINGLE_TRACK:
             Log.d("LT", "Playing single song finished. Stopping.");


### PR DESCRIPTION
The reason for the jittering audio seems to be the continuous `mediaPlayer.reset()` which happens if play() is called with `doCont=true`.

This change fixes the issue for me.

Thanks

Kambiz
